### PR TITLE
Fix Expo compatibility dependencies

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -9,8 +9,8 @@
     "web": "expo start --web"
   },
   "dependencies": {
-    "@react-native-async-storage/async-storage": "^2.2.0",
-    "@react-native-community/slider": "^4.5.7",
+    "@react-native-async-storage/async-storage": "2.1.2",
+    "@react-native-community/slider": "4.5.6",
     "@react-navigation/native": "^6.1.7",
     "@react-navigation/stack": "^6.3.23",
     "axios": "^1.6.8",
@@ -18,7 +18,7 @@
     "react": "19.0.0",
     "react-native": "0.79.4",
     "react-native-screens": "^4.0.0",
-    "react-native-safe-area-context": "^4.12.0",
-    "react-native-gesture-handler": "^2.20.0"
+    "react-native-safe-area-context": "5.4.0",
+    "react-native-gesture-handler": "~2.24.0"
   }
 }


### PR DESCRIPTION
## Summary
- pin React Native packages to Expo-recommended versions

## Testing
- `npm audit --audit-level=high` in `app`
- `npm start` (Expo)

------
https://chatgpt.com/codex/tasks/task_e_685a18e86048832a84315e844c5b53c8